### PR TITLE
Add GitHub Release job to build-plugin.yml for automated versioning a…

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -118,6 +118,69 @@ jobs:
         path: build/
         retention-days: 7
 
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Get plugin version
+      id: version
+      run: |
+        VERSION=$(grep "Version:" wupz-plugin/wupz.php | head -1 | awk -F: '{print $2}' | xargs)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: wupz-plugin-${{ steps.version.outputs.version }}
+        path: ./
+    
+    - name: Create Release
+      uses: actions/create-release@v1
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Wupz v${{ steps.version.outputs.version }}
+        body: |
+          ## Wupz WordPress Backup Plugin v${{ steps.version.outputs.version }}
+          
+          ### Installation
+          1. Download the `wupz-${{ steps.version.outputs.version }}.zip` file below
+          2. Go to WordPress Admin → Plugins → Add New → Upload Plugin
+          3. Upload the ZIP file and activate the plugin
+          
+          ### Features
+          - Manual and scheduled backups
+          - Database and file backups
+          - Email notifications
+          - System status monitoring
+          - Easy-to-use admin interface
+          
+          ### Documentation
+          Visit our [Wiki](https://github.com/danielgtmn/Wupz/wiki) for detailed documentation.
+          
+          ---
+          **Full Changelog**: https://github.com/danielgtmn/Wupz/compare/v${{ steps.version.outputs.version }}
+        draft: false
+        prerelease: false
+    
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./wupz-${{ steps.version.outputs.version }}.zip
+        asset_name: wupz-${{ steps.version.outputs.version }}.zip
+        asset_content_type: application/zip
+
 
 
  


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow step to automate the creation of GitHub Releases for the Wupz WordPress Backup Plugin. The most significant change is the addition of a `release` job that handles tagging, artifact uploading, and release creation.

### Workflow Enhancements:

* **Automated GitHub Release Creation**: Added a `release` job to `.github/workflows/build-plugin.yml` that triggers on tag creation (`refs/tags/`). It automates the process of creating a release, including fetching the plugin version, downloading build artifacts, and uploading them as release assets.…nd release creation